### PR TITLE
Add Dockerfile to build a Docker image for SDK Doctor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:latest as builder
+WORKDIR /go/src/github.com/couchbaselabs/sdk-doctor/
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+COPY ./ ./
+RUN go get -t && \
+    go test ./ && \
+    go build -a -installsuffix cgo -o sdk-doctor-linux .
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+WORKDIR /sdk-doctor
+COPY --from=builder /go/src/github.com/couchbaselabs/sdk-doctor/sdk-doctor-linux .
+ENTRYPOINT ["./sdk-doctor-linux"]


### PR DESCRIPTION
Motivation
----------
Easily run SDK Doctor on any system with Docker installed, without
downloading/installing binaries.  Also, easily run SDK Doctor on a
Kubernetes cluster to test connectivity in situ.

Modifications
-------------
Added a Dockerfile to perform build.

Results
-------
Running `docker build -t tagname .` will build a slim Docker image using
a multi-stage build.

An example build is currently available on Docker Hub at
`btburnett3/sdk-doctor`.

Usage:

```
docker run --rm btburnett3/sdk-doctor diagnose couchbase://node/bucket
```

Kubernetes usage:
```
kubectl run sdktest --rm -i --image btburnett3/sdk-doctor -- diagnose couchbase://node/bucket
```

It would be desirable to include this build process in .travis.yml and
publish the image to `couchbase/sdk-doctor`, but I lack the credentials
so did not include it at this time.