### PR TITLE
Support for reverse proxy bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ For 5.0+ production clusters configured with the suggested security standards, y
 sdk-doctor diagnose couchbase://127.0.0.1/default -u Administrator -p password
 ```
 
+For clusters using an HTTP reverse proxy or load balancer for bootstrapping (instead of CCCP), use the `--reverse-proxy` flag.
+This suppresses certain tests which don't apply to this configuration.
+
+```bash
+sdk-doctor diagnose couchbase://127.0.0.1/default --reverse-proxy
+```
+
 ### How To Build
 The build steps are similar to most go programs.  Given a properly set up go build environment:
 


### PR DESCRIPTION
Motivation
----------
Some clusters are configured to bootstrap via a single reverse proxy (or
load balancer) using HTTP.  This configuration has the advantage of
making it easy to configure disparate microservices to connect to the
cluster, and also allows full cluster swaps using XDCR during cluster
maintenance.  The SDK Doctor currently throws errors and warnings
connecting to a cluster using this configuration.

Modifications
-------------
Add a new flag `--reverse-proxy` which:

1.  Suppresses tests which are not applicable to this configuration
2.  Suppresses attempts to connect via CCCP
3.  Warns if there is more than 1 host in the connection string, rather
than the default warning if there aren't at least 2 hosts.

Results
-------
Clusters configured using the more advanced reverse proxy bootstrap will
now test cleanly if the new flag is supplied.  The default behavior is
unchanged.