### PR TITLE
Add Docker build to Travis CI process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: go
 go:
   - 1.7.x
+sudo: required
+services:
+  - docker
 install:
   - go get -t
   - GOOS=darwin GOARCH=amd64 go get
@@ -11,8 +14,9 @@ script:
   - GOOS=darwin GOARCH=amd64 go build -o sdk-doctor-macos
   - GOOS=linux GOARCH=amd64 go build -o sdk-doctor-linux
   - GOOS=windows GOARCH=amd64 go build -o sdk-doctor-windows.exe
+  - docker build -t couchbase/sdk-doctor:${TRAVIS_BUILD_NUMBER} .
 deploy:
-  provider: releases
+- provider: releases
   api_key:
     secure: CfrzySK7rEYKMZWBKcsBGHZLCnuoQYBR+tw/l1CNa9JjeUPAWMBZAKFqdXkAy+05+ChaYSIXDpcRhU3Sk78hk6R39FzbFSw0/xlwdGa3gdhomLqEyZ8hqzfSaZBZpNeERX6nLZ/C/Ee1KVGtcoyQL3FV5akYTFZBsqRsab0YX619yFJiRyCuUWo/9LViS5nwn5/YtPN4uVyj/qX139oJ35bJGGYPuVTv+12HDi6lKYZ+OtjT6Y/dF9awAtcK7nsPrNsQ1a5u4QJqlSzwAYluS8+Yat96E9EzTvXfOjDFECqCrKo5VhIqfQ6HNbjoxQ/p0vMEIU2JYMFg2idkOFLm1EB9rumPlArLpce+x6oBruJICbgTJ5JpTCTZhMBrTH35arzHY424xpRHx0QmfKmP7Fn246oaOwlCIK+HI1jzOIOMKM6NPOuEwiYJ4W7D2uCvbJaBwk8Qm7L9xZZIwQeo+7rDugDysOS8X2KrIBegzKj9fMh7OmIPLCE4xdU0EVfEwXli1FHT75vYxsbryRqDaRxJ8UV7EBNynwzaMxVeKmIJe7A/ugYMQ6L7vVkWLvC+wI+KWgmOLeTXZdq1EMIFYsLxb9R4/JHah7NBij0XAOYKw/iyjh9SQ+2THQcAAsDnze3jt1pw837JWdLgKRR9fP1rUut+BTJnKCg7mvKH4a0=
   file:
@@ -20,6 +24,11 @@ deploy:
     - sdk-doctor-linux
     - sdk-doctor-windows.exe
   skip_cleanup: true
+  on:
+    repo: couchbaselabs/sdk-doctor
+    tags: true
+- provider: script
+  script: build/docker_push.sh
   on:
     repo: couchbaselabs/sdk-doctor
     tags: true

--- a/build/docker_push.sh
+++ b/build/docker_push.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+docker tag couchbase/sdk-doctor:${TRAVIS_BUILD_NUMBER} couchbase/sdk-doctor:${TRAVIS_TAG}
+docker tag couchbase/sdk-doctor:${TRAVIS_BUILD_NUMBER} couchbase/sdk-doctor:latest
+docker push couchbase/sdk-doctor:${TRAVIS_TAG}
+docker push couchbase/sdk-doctor:latest


### PR DESCRIPTION
Motivation
----------
Ensure that the Docker build is successful on pull requests, and also
publish the image to Docker Hub on tags.

Modifications
-------------
Add Docker build to the build script.

Add a Docker publish process on tags to the deploy steps.

Results
-------
A Docker image is always built, but it is also published when tagged
using the tagged version as well as the ":latest" tag.

The deploy process expects the DOCKER_USERNAME and DOCKER_PASSWORD
environment variables to be present in the Travis configuration.  See
https://docs.travis-ci.com/user/docker/#Pushing-a-Docker-Image-to-a-Registry.